### PR TITLE
Custom user script directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .tags
 .tags_sorted_by_file
 .settings
+.autotools
+.vscode/

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -92,35 +92,22 @@ QDir UserScriptDir()
 
 std::vector<QDir> CustomUserScriptDirs()
 {
+	QSettings settings;
+	QStringList userPaths = settings.value("customUserScriptPaths").toStringList();
+
 	std::vector<QDir> vCustomUserScriptDirs;
 
-	if(UserDataDir().exists("custom_user_script_dirs")){
-		QFile inFile((app::UserDataDir().absoluteFilePath("custom_user_script_dirs")));
+	for(int i = 0; i < userPaths.size(); ++i){
+		QDir customUserScriptDir;
+		customUserScriptDir.setPath(userPaths[i]);
 
-		if (inFile.open(QIODevice::ReadOnly | QIODevice::Text))
-		{
-		   QTextStream inStr(&inFile);
+   	// 	Path permission check
+		QString pathName(customUserScriptDir.dirName());
+		customUserScriptDir.cdUp();
+		CheckPathPermissions(customUserScriptDir, pathName);
 
-		   while(!inStr.atEnd())
-		   {
-			   QString line = inStr.readLine();
-			   if(!line.isEmpty()){
-				   QDir currentCustomUserScriptDir;
-				   currentCustomUserScriptDir.setPath(line);
-
-			   //  Path permission check
-				   QString pathName(currentCustomUserScriptDir.dirName());
-				   currentCustomUserScriptDir.cdUp();
-				   CheckPathPermissions(currentCustomUserScriptDir, pathName);
-
-				   currentCustomUserScriptDir.cd(pathName);
-
-				   vCustomUserScriptDirs.push_back(currentCustomUserScriptDir);
-			   }
-		   }
-
-		   inFile.close();
-		}
+		customUserScriptDir.cd(pathName);
+		vCustomUserScriptDirs.push_back(customUserScriptDir);
 	}
 
 	return vCustomUserScriptDirs;

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -70,7 +70,6 @@ QDir UserDataDir()
 
 	homeDir.cd(pathName);
 
-
 	return homeDir;
 }
 
@@ -88,6 +87,25 @@ QDir UserScriptDir()
 	userPath.cd(pathName);
 
 	return userPath;
+}
+
+QDir CustomUserScriptDir()
+{
+	QDir customUserPath = UserScriptDir();
+
+	if(UserDataDir().exists("custom_user_script_path")){
+		customUserPath.setPath(GetFileContent(app::UserDataDir().absoluteFilePath("custom_user_script_path")));
+	}
+
+	QString pathName(customUserPath.dirName());
+
+	customUserPath.cdUp();
+
+	CheckPathPermissions(customUserPath, pathName);
+
+	customUserPath.cd(pathName);
+
+	return customUserPath;
 }
 
 QDir UserTmpDir()

--- a/src/app.h
+++ b/src/app.h
@@ -94,8 +94,8 @@ QDir UserDataDir();
 ///	returns the path in which user-scripts are placed (e.g. $HOME/.promesh/scripts)
 QDir UserScriptDir();
 
-///	returns the user specified path in which custom user scripts are placed
-QDir CustomUserScriptDir();
+///	returns the user specified paths in which custom user scripts are placed
+std::vector<QDir> CustomUserScriptDirs();
 
 ///	returns the path in which temporary data may be placed (e.g. $HOME/.promesh/tmp)
 QDir UserTmpDir();

--- a/src/app.h
+++ b/src/app.h
@@ -94,6 +94,9 @@ QDir UserDataDir();
 ///	returns the path in which user-scripts are placed (e.g. $HOME/.promesh/scripts)
 QDir UserScriptDir();
 
+///	returns the user specified path in which custom user scripts are placed
+QDir CustomUserScriptDir();
+
 ///	returns the path in which temporary data may be placed (e.g. $HOME/.promesh/tmp)
 QDir UserTmpDir();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -116,7 +116,7 @@ int main(int argc, char *argv[])
 	
 	QCoreApplication::setOrganizationName("ProMesh");
     QCoreApplication::setOrganizationDomain("promesh3d.com");
-    QCoreApplication::setApplicationName("ProMesh4.3.18");
+    QCoreApplication::setApplicationName("ProMesh");
 
     {
     //	write the absolute path of the application to .promesh/promesh_home

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -116,7 +116,7 @@ int main(int argc, char *argv[])
 	
 	QCoreApplication::setOrganizationName("ProMesh");
     QCoreApplication::setOrganizationDomain("promesh3d.com");
-    QCoreApplication::setApplicationName("ProMesh4.3.10");
+    QCoreApplication::setApplicationName("ProMesh4.3.18");
 
     {
     //	write the absolute path of the application to .promesh/promesh_home

--- a/src/modules/mesh_module.cpp
+++ b/src/modules/mesh_module.cpp
@@ -177,19 +177,19 @@ activate(SceneInspector* sceneInspector, LGScene* scene)
 		actRefreshToolDialogs->setStatusTip("Refreshes contents of the tool-dialogs.");
 		connect(actRefreshToolDialogs, SIGNAL(triggered()), this, SLOT(refreshToolDialogsClicked()));
 
-		QAction* actAddCustomUserScriptFolder = new QAction(tr("Add Custom User Script Folder"), parentWidget());
-		actAddCustomUserScriptFolder->setStatusTip("Adds Custom User Scripts located in the specified folder to the tool-dialog.");
-		connect(actAddCustomUserScriptFolder, SIGNAL(triggered()), this, SLOT(addCustomUserScriptFolder()));
+		QAction* actAddCustomUserScriptDir = new QAction(tr("Add Custom User Script Directory"), parentWidget());
+		actAddCustomUserScriptDir->setStatusTip("Adds Custom User Scripts located in the specified folder to the tool-dialog.");
+		connect(actAddCustomUserScriptDir, SIGNAL(triggered()), this, SLOT(addCustomUserScriptDir()));
 
-		QAction* actRemoveCustomUserScriptFolder = new QAction(tr("Remove Custom User Script Folder"), parentWidget());
-		actRemoveCustomUserScriptFolder->setStatusTip("Removes Custom User Scripts from the tool-dialog.");
-		connect(actRemoveCustomUserScriptFolder, SIGNAL(triggered()), this, SLOT(removeCustomUserScriptFolder()));
+		QAction* actRemoveCustomUserScriptDirs = new QAction(tr("Remove Custom User Script Directories"), parentWidget());
+		actRemoveCustomUserScriptDirs->setStatusTip("Removes Custom User Scripts from the tool-dialog.");
+		connect(actRemoveCustomUserScriptDirs, SIGNAL(triggered()), this, SLOT(removeCustomUserScriptDirs()));
 
 		QMenu* sceneMenu = new QMenu("&Scripts", parentWidget());
 		sceneMenu->addAction(actNewScript);
 		sceneMenu->addAction(actEditScript);
-		sceneMenu->addAction(actAddCustomUserScriptFolder);
-		sceneMenu->addAction(actRemoveCustomUserScriptFolder);
+		sceneMenu->addAction(actAddCustomUserScriptDir);
+		sceneMenu->addAction(actRemoveCustomUserScriptDirs);
 		sceneMenu->addSeparator();
 		sceneMenu->addAction(actBrowseUserScripts);
 		sceneMenu->addSeparator();
@@ -301,22 +301,29 @@ void MeshModule::browseUserScripts()
 	QDesktopServices::openUrl(QUrl("file:///" + path));
 }
 
-void MeshModule::addCustomUserScriptFolder()
+void MeshModule::addCustomUserScriptDir()
 {
-	QString customUserScriptPath = QFileDialog::getExistingDirectory(parentWidget(),
+	QString customUserScriptDir = QFileDialog::getExistingDirectory(parentWidget(),
 													tr("Open Directory"),
 													QDir::toNativeSeparators(QDir::home().path()),
 	                                                QFileDialog::ShowDirsOnly
 	                                                | QFileDialog::DontResolveSymlinks);
 
-	SetFileContent(app::UserDataDir().absoluteFilePath("custom_user_script_path"), customUserScriptPath);
+	if(!customUserScriptDir.isEmpty()){
+		QFile outFile(app::UserDataDir().absoluteFilePath("custom_user_script_dirs"));
+		outFile.open(QIODevice::Append | QIODevice::Text);
+		outFile.write(customUserScriptDir.toLocal8Bit());
+		outFile.write("\n");
+		outFile.close();
+	}
+
 	refreshToolDialogsClicked();
 }
 
-void MeshModule::removeCustomUserScriptFolder()
+void MeshModule::removeCustomUserScriptDirs()
 {
-	if(app::UserDataDir().exists("custom_user_script_path")){
-		QFile file(app::UserDataDir().absoluteFilePath("custom_user_script_path"));
+	if(app::UserDataDir().exists("custom_user_script_dirs")){
+		QFile file(app::UserDataDir().absoluteFilePath("custom_user_script_dirs"));
 		file.remove();
 	}
 

--- a/src/modules/mesh_module.cpp
+++ b/src/modules/mesh_module.cpp
@@ -303,18 +303,17 @@ void MeshModule::browseUserScripts()
 
 void MeshModule::addCustomUserScriptDir()
 {
-	QString customUserScriptDir = QFileDialog::getExistingDirectory(parentWidget(),
+	QString customUserScriptDirPath = QFileDialog::getExistingDirectory(parentWidget(),
 													tr("Open Directory"),
 													QDir::toNativeSeparators(QDir::home().path()),
 	                                                QFileDialog::ShowDirsOnly
 	                                                | QFileDialog::DontResolveSymlinks);
 
-	if(!customUserScriptDir.isEmpty()){
-		QFile outFile(app::UserDataDir().absoluteFilePath("custom_user_script_dirs"));
-		outFile.open(QIODevice::Append | QIODevice::Text);
-		outFile.write(customUserScriptDir.toLocal8Bit());
-		outFile.write("\n");
-		outFile.close();
+	if(!customUserScriptDirPath.isEmpty()){
+		QSettings settings;
+		QStringList customUserPaths = settings.value("customUserScriptPaths").toStringList();
+		customUserPaths.push_back(customUserScriptDirPath);
+		settings.setValue("customUserScriptPaths", customUserPaths);
 	}
 
 	refreshToolDialogsClicked();
@@ -322,10 +321,8 @@ void MeshModule::addCustomUserScriptDir()
 
 void MeshModule::removeCustomUserScriptDirs()
 {
-	if(app::UserDataDir().exists("custom_user_script_dirs")){
-		QFile file(app::UserDataDir().absoluteFilePath("custom_user_script_dirs"));
-		file.remove();
-	}
+	QSettings settings;
+	settings.remove("customUserScriptPaths");
 
 	QMessageBox msgBox;
 	msgBox.setText("Changes will take effect after restart.");

--- a/src/modules/mesh_module.h
+++ b/src/modules/mesh_module.h
@@ -72,6 +72,8 @@ public:
 protected slots:
 	void refreshToolDialogsClicked();
 	void browseUserScripts();
+	void addCustomUserScriptFolder();
+	void removeCustomUserScriptFolder();
 	void newScript();
 	void editScript();
 	void refreshCoordinates();

--- a/src/modules/mesh_module.h
+++ b/src/modules/mesh_module.h
@@ -72,8 +72,8 @@ public:
 protected slots:
 	void refreshToolDialogsClicked();
 	void browseUserScripts();
-	void addCustomUserScriptFolder();
-	void removeCustomUserScriptFolder();
+	void addCustomUserScriptDir();
+	void removeCustomUserScriptDirs();
 	void newScript();
 	void editScript();
 	void refreshCoordinates();

--- a/src/tools/script_tools.cpp
+++ b/src/tools/script_tools.cpp
@@ -286,14 +286,12 @@ void RegisterScriptTools(ToolManager* toolMgr)
 	ParseDirAndCreateTools(toolMgr, QDir(":/scripts"), "Scripts", shell);
 	ParseDirAndCreateTools(toolMgr, app::UserScriptDir(), "Scripts", shell);
 
-	if(app::UserDataDir().exists("custom_user_script_dirs")){
-		std::vector<QDir> vDirs = app::CustomUserScriptDirs();
+	std::vector<QDir> vDirs = app::CustomUserScriptDirs();
 
-		for(int i = 0; i < vDirs.size(); ++i){
-			QString scriptGroupName = "Scripts | " + vDirs[i].dirName();
-			ParseDirAndCreateTools(toolMgr, vDirs[i],
-					scriptGroupName.toLocal8Bit().constData(), shell);
-		}
+	for(int i = 0; i < vDirs.size(); ++i){
+		QString scriptGroupName = "Scripts | " + vDirs[i].dirName();
+		ParseDirAndCreateTools(toolMgr, vDirs[i],
+				scriptGroupName.toLocal8Bit().constData(), shell);
 	}
 }
 
@@ -327,14 +325,12 @@ int RefreshScriptTools(ToolManager* toolMgr)
 	ParseDirAndCreateTools(toolMgr, QDir(":/scripts"), "Scripts", luaShell, true);
 	ParseDirAndCreateTools(toolMgr, app::UserScriptDir(), "Scripts", luaShell, true);
 
-	if(app::UserDataDir().exists("custom_user_script_dirs")){
-		std::vector<QDir> vDirs = app::CustomUserScriptDirs();
+	std::vector<QDir> vDirs = app::CustomUserScriptDirs();
 
-		for(int i = 0; i < vDirs.size(); ++i){
-			QString scriptGroupName = "Scripts | " + vDirs[i].dirName();
-			ParseDirAndCreateTools(toolMgr, vDirs[i],
-					scriptGroupName.toLocal8Bit().constData(), luaShell, true);
-		}
+	for(int i = 0; i < vDirs.size(); ++i){
+		QString scriptGroupName = "Scripts | " + vDirs[i].dirName();
+		ParseDirAndCreateTools(toolMgr, vDirs[i],
+				scriptGroupName.toLocal8Bit().constData(), luaShell, true);
 	}
 
 	if(lastNumScriptTools != g_scriptTools.size())

--- a/src/tools/script_tools.cpp
+++ b/src/tools/script_tools.cpp
@@ -285,6 +285,10 @@ void RegisterScriptTools(ToolManager* toolMgr)
 	SmartPtr<luashell::LuaShell> shell = make_sp(new luashell::LuaShell());
 	ParseDirAndCreateTools(toolMgr, QDir(":/scripts"), "Scripts", shell);
 	ParseDirAndCreateTools(toolMgr, app::UserScriptDir(), "Scripts", shell);
+
+	if(app::UserDataDir().exists("custom_user_script_path")){
+		ParseDirAndCreateTools(toolMgr, app::CustomUserScriptDir(), "Scripts | Custom User Scripts", shell);
+	}
 }
 
 int RefreshScriptTools(ToolManager* toolMgr)
@@ -316,6 +320,10 @@ int RefreshScriptTools(ToolManager* toolMgr)
 
 	ParseDirAndCreateTools(toolMgr, QDir(":/scripts"), "Scripts", luaShell, true);
 	ParseDirAndCreateTools(toolMgr, app::UserScriptDir(), "Scripts", luaShell, true);
+
+	if(app::UserDataDir().exists("custom_user_script_path")){
+		ParseDirAndCreateTools(toolMgr, app::CustomUserScriptDir(), "Scripts | Custom User Scripts", luaShell, true);
+	}
 
 	if(lastNumScriptTools != g_scriptTools.size())
 		retVal = 1;

--- a/src/tools/script_tools.cpp
+++ b/src/tools/script_tools.cpp
@@ -286,8 +286,14 @@ void RegisterScriptTools(ToolManager* toolMgr)
 	ParseDirAndCreateTools(toolMgr, QDir(":/scripts"), "Scripts", shell);
 	ParseDirAndCreateTools(toolMgr, app::UserScriptDir(), "Scripts", shell);
 
-	if(app::UserDataDir().exists("custom_user_script_path")){
-		ParseDirAndCreateTools(toolMgr, app::CustomUserScriptDir(), "Scripts | Custom User Scripts", shell);
+	if(app::UserDataDir().exists("custom_user_script_dirs")){
+		std::vector<QDir> vDirs = app::CustomUserScriptDirs();
+
+		for(int i = 0; i < vDirs.size(); ++i){
+			QString scriptGroupName = "Scripts | " + vDirs[i].dirName();
+			ParseDirAndCreateTools(toolMgr, vDirs[i],
+					scriptGroupName.toLocal8Bit().constData(), shell);
+		}
 	}
 }
 
@@ -321,8 +327,14 @@ int RefreshScriptTools(ToolManager* toolMgr)
 	ParseDirAndCreateTools(toolMgr, QDir(":/scripts"), "Scripts", luaShell, true);
 	ParseDirAndCreateTools(toolMgr, app::UserScriptDir(), "Scripts", luaShell, true);
 
-	if(app::UserDataDir().exists("custom_user_script_path")){
-		ParseDirAndCreateTools(toolMgr, app::CustomUserScriptDir(), "Scripts | Custom User Scripts", luaShell, true);
+	if(app::UserDataDir().exists("custom_user_script_dirs")){
+		std::vector<QDir> vDirs = app::CustomUserScriptDirs();
+
+		for(int i = 0; i < vDirs.size(); ++i){
+			QString scriptGroupName = "Scripts | " + vDirs[i].dirName();
+			ParseDirAndCreateTools(toolMgr, vDirs[i],
+					scriptGroupName.toLocal8Bit().constData(), luaShell, true);
+		}
 	}
 
 	if(lastNumScriptTools != g_scriptTools.size())


### PR DESCRIPTION
Dear Sebastian,

we discussed this topic a while ago and recently I have taken a shot at extending ProMesh to support the addition and removal of custom user script directories for monitoring -- analogously to the default directory ./promesh/scripts. To this end, the user-specified directories are stored in ./promesh/custom_user_script_dirs. 

In this context, it would be generally useful to facilitate referring to additional data, e.g. raster files, using relative paths in scripts that are executed from within ProMesh, but I haven't been able to resolve this issue yet.

Best,
Martin